### PR TITLE
6-missing-namespace-in-function-exists-call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Added missing namespace `Folded` to `function_exists` statements.
+
 ## [0.1.1] 2020-09-18
 
 ### Fixed

--- a/src/addRequestedUrlToHistory.php
+++ b/src/addRequestedUrlToHistory.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("addRequestedUrlToHistory")) {
+if (!function_exists("Folded\addRequestedUrlToHistory")) {
     /**
      * Add the current browsed URL to the history.
      *

--- a/src/getAllHistory.php
+++ b/src/getAllHistory.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("getAllHistory")) {
+if (!function_exists("Folded\getAllHistory")) {
     /**
      * Get all the URLs stored in the history.
      *

--- a/src/getHistory.php
+++ b/src/getHistory.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("getHistory")) {
+if (!function_exists("Folded\getHistory")) {
     /**
      * Get the URL in the history at a given index.
      * Let it empty to get the last URL in the history.

--- a/src/hasHistory.php
+++ b/src/hasHistory.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("hasHistory")) {
+if (!function_exists("Folded\hasHistory")) {
     /**
      * Returns true if the index is present in the history.
      *


### PR DESCRIPTION
## Added

None.

## Fixed

- Bug when namespace `Folded` was missing from `function_exists` statements.

## Breaking

None.